### PR TITLE
Add check on if conference.name exists

### DIFF
--- a/src/containers/EventsContainer.js
+++ b/src/containers/EventsContainer.js
@@ -1,12 +1,15 @@
-import { connect } from "react-redux";
+import { connect } from 'react-redux';
 
-import EventsList from "../components/EventsList";
-import { getAllConferences, filterConferences } from "../actions";
+import EventsList from '../components/EventsList';
+import { getAllConferences, filterConferences } from '../actions';
 
 const mapStateToProps = ({ conferences, loading, errors, search }) => ({
   conferences,
-  filteredConferences: conferences.filter(conference =>
-    conference.name.toLowerCase().includes(search.toLowerCase())
+  filteredConferences: conferences.filter(
+    conference =>
+      conference.name // check if the conference object has a name
+        ? conference.name.toLowerCase().includes(search.toLowerCase())
+        : false
   ),
   isLoading: loading,
   hasErrors: errors,


### PR DESCRIPTION
Trello Number: --

Task: Add check on if conference.name exists when filtering list of conferences on search text

What does this code do?
Adds an extra check on if the conference name exists! If it doesn't, it won't be included in the search results

Do I need to yarn install?
no

Success criteria:
1. Everything should work as expected
2. If there's an event with no name (there shouldn't be!) - the app won't crash

![noname](https://user-images.githubusercontent.com/15068364/44060397-93293472-9f22-11e8-992b-18b075b7b0ee.gif)

